### PR TITLE
Support for "raw" pages and custom controls margin

### DIFF
--- a/lib/src/introduction_screen.dart
+++ b/lib/src/introduction_screen.dart
@@ -13,6 +13,9 @@ class IntroductionScreen extends StatefulWidget {
   /// All pages of the onboarding
   final List<PageViewModel> pages;
 
+  /// All pages of the onboarding, as a complete widget instead of a PageViewModel
+  final List<Widget> rawPages;
+
   /// Callback when Done button is pressed
   final VoidCallback onDone;
 
@@ -104,36 +107,37 @@ class IntroductionScreen extends StatefulWidget {
   /// Color of done button
   final Color doneColor;
 
-
-  const IntroductionScreen({
-    Key key,
-    @required this.pages,
-    @required this.onDone,
-    @required this.done,
-    this.onSkip,
-    this.onChange,
-    this.skip,
-    this.next,
-    this.showSkipButton = false,
-    this.showNextButton = true,
-    this.isProgress = true,
-    this.isProgressTap = true,
-    this.freeze = false,
-    this.globalBackgroundColor,
-    this.dotsDecorator = const DotsDecorator(),
-    this.animationDuration = 350,
-    this.initialPage = 0,
-    this.skipFlex = 1,
-    this.dotsFlex = 1,
-    this.nextFlex = 1,
-    this.curve = Curves.easeIn,
-    this.color,
-    this.skipColor,
-    this.nextColor,
-    this.doneColor
-  })  : assert(pages != null),
+  const IntroductionScreen(
+      {Key key,
+      this.pages,
+      this.rawPages,
+      @required this.onDone,
+      @required this.done,
+      this.onSkip,
+      this.onChange,
+      this.skip,
+      this.next,
+      this.showSkipButton = false,
+      this.showNextButton = true,
+      this.isProgress = true,
+      this.isProgressTap = true,
+      this.freeze = false,
+      this.globalBackgroundColor,
+      this.dotsDecorator = const DotsDecorator(),
+      this.animationDuration = 350,
+      this.initialPage = 0,
+      this.skipFlex = 1,
+      this.dotsFlex = 1,
+      this.nextFlex = 1,
+      this.curve = Curves.easeIn,
+      this.color,
+      this.skipColor,
+      this.nextColor,
+      this.doneColor})
+      : assert(pages != null || rawPages != null),
         assert(
-          pages.length > 0,
+          (pages != null && pages.length > 0) ||
+              (rawPages != null && rawPages.length > 0),
           "You provide at least one page on introduction screen !",
         ),
         assert(onDone != null),
@@ -234,7 +238,9 @@ class IntroductionScreenState extends State<IntroductionScreen> {
               physics: widget.freeze
                   ? const NeverScrollableScrollPhysics()
                   : const BouncingScrollPhysics(),
-              children: widget.pages.map((p) => IntroPage(page: p)).toList(),
+              children: widget.pages != null
+                  ? widget.pages.map((p) => IntroPage(page: p)).toList()
+                  : widget.rawPages,
               onPageChanged: widget.onChange,
             ),
           ),

--- a/lib/src/introduction_screen.dart
+++ b/lib/src/introduction_screen.dart
@@ -276,7 +276,7 @@ class IntroductionScreenState extends State<IntroductionScreen> {
                           ? DotsIndicator(
                               dotsCount: widget.pages != null
                                   ? widget.pages.length
-                                  : widget.rawPages,
+                                  : widget.rawPages.length,
                               position: _currentPage,
                               decorator: widget.dotsDecorator,
                               onTap: widget.isProgressTap && !widget.freeze

--- a/lib/src/introduction_screen.dart
+++ b/lib/src/introduction_screen.dart
@@ -107,6 +107,8 @@ class IntroductionScreen extends StatefulWidget {
   /// Color of done button
   final Color doneColor;
 
+  final EdgeInsets controlsMargin;
+
   const IntroductionScreen(
       {Key key,
       this.pages,
@@ -133,7 +135,9 @@ class IntroductionScreen extends StatefulWidget {
       this.color,
       this.skipColor,
       this.nextColor,
-      this.doneColor})
+      this.doneColor,
+      this.controlsMargin =
+          const EdgeInsets.only(left: 16.0, right: 16.0, bottom: 16.0)})
       : assert(pages != null || rawPages != null),
         assert(
           (pages != null && pages.length > 0) ||
@@ -257,9 +261,9 @@ class IntroductionScreenState extends State<IntroductionScreen> {
             ),
           ),
           Positioned(
-            bottom: 16.0,
-            left: 16.0,
-            right: 16.0,
+            bottom: widget.controlsMargin.bottom,
+            left: widget.controlsMargin.left,
+            right: widget.controlsMargin.right,
             child: SafeArea(
               child: Row(
                 children: [

--- a/lib/src/introduction_screen.dart
+++ b/lib/src/introduction_screen.dart
@@ -162,13 +162,19 @@ class IntroductionScreenState extends State<IntroductionScreen> {
   @override
   void initState() {
     super.initState();
-    int initialPage = min(widget.initialPage, widget.pages.length - 1);
+    int length =
+        (widget.pages != null ? widget.pages.length : widget.rawPages.length) -
+            1;
+    int initialPage = min(widget.initialPage, length);
     _currentPage = initialPage.toDouble();
     _pageController = PageController(initialPage: initialPage);
   }
 
   void next() {
-    animateScroll(min(_currentPage.round() + 1, widget.pages.length - 1));
+    int length =
+        (widget.pages != null ? widget.pages.length : widget.rawPages.length) -
+            1;
+    animateScroll(min(_currentPage.round() + 1, length));
   }
 
   Future<void> _onSkip() async {
@@ -178,7 +184,10 @@ class IntroductionScreenState extends State<IntroductionScreen> {
 
   Future<void> skipToEnd() async {
     setState(() => _isSkipPressed = true);
-    await animateScroll(widget.pages.length - 1);
+    int length =
+        (widget.pages != null ? widget.pages.length : widget.rawPages.length) -
+            1;
+    await animateScroll(length);
     if (mounted) {
       setState(() => _isSkipPressed = false);
     }
@@ -206,7 +215,10 @@ class IntroductionScreenState extends State<IntroductionScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final isLastPage = (_currentPage.round() == widget.pages.length - 1);
+    int length =
+        (widget.pages != null ? widget.pages.length : widget.rawPages.length) -
+            1;
+    final isLastPage = (_currentPage.round() == length);
     bool isSkipBtn = (!_isSkipPressed && !isLastPage && widget.showSkipButton);
 
     final skipBtn = IntroButton(
@@ -262,7 +274,9 @@ class IntroductionScreenState extends State<IntroductionScreen> {
                     child: Center(
                       child: widget.isProgress
                           ? DotsIndicator(
-                              dotsCount: widget.pages.length,
+                              dotsCount: widget.pages != null
+                                  ? widget.pages.length
+                                  : widget.rawPages,
                               position: _currentPage,
                               decorator: widget.dotsDecorator,
                               onTap: widget.isProgressTap && !widget.freeze


### PR DESCRIPTION
The package is very nice, but it could be difficult to implement a custom design (for example, I need to put the image BELOW the title and the text).
Following the usual Flutter methodology, I added the parameter `rawPages` in the construct. It shall be an array of widget and, if it is not null, it will be used in the `PageView`.

Moreover, I also added the possibility to customize the padding (or margin) of the controllers, with the `controlsMargin` parameter.