### PR TITLE
Remove SingleChildScrollView from body widget

### DIFF
--- a/lib/src/ui/intro_page.dart
+++ b/lib/src/ui/intro_page.dart
@@ -29,10 +29,7 @@ class IntroPage extends StatelessWidget {
               flex: page.decoration.bodyFlex,
               child: Padding(
                 padding: const EdgeInsets.only(bottom: 70.0),
-                child: SingleChildScrollView(
-                  physics: const BouncingScrollPhysics(),
-                  child: IntroContent(page: page),
-                ),
+                child: IntroContent(page: page),
               ),
             ),
           ],


### PR DESCRIPTION
Removed SingleChildScrollView from body widget. 
https://github.com/Pyozer/introduction_screen/issues/56