### PR TITLE
Allow body widget to be built without padding

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -56,7 +56,7 @@ class _OnBoardingPageState extends State<OnBoardingPage> {
     const pageDecoration = const PageDecoration(
       titleTextStyle: TextStyle(fontSize: 28.0, fontWeight: FontWeight.w700),
       bodyTextStyle: bodyStyle,
-      descriptionPadding: EdgeInsets.fromLTRB(16.0, 0.0, 16.0, 16.0),
+      bodyPadding: EdgeInsets.fromLTRB(16.0, 0.0, 16.0, 16.0),
       pageColor: Colors.white,
       imagePadding: EdgeInsets.zero,
     );

--- a/lib/src/model/page_decoration.dart
+++ b/lib/src/model/page_decoration.dart
@@ -39,8 +39,6 @@ class PageDecoration {
   final EdgeInsets titlePadding;
 
   /// Padding of body
-  ///
-  /// @Default: `EdgeInsets.zero`
   final EdgeInsets? bodyPadding;
 
   /// Padding of footer

--- a/lib/src/model/page_decoration.dart
+++ b/lib/src/model/page_decoration.dart
@@ -38,10 +38,10 @@ class PageDecoration {
   /// @Default `EdgeInsets.only(top: 16.0, bottom: 24.0)`
   final EdgeInsets titlePadding;
 
-  /// Padding of description
+  /// Padding of body
   ///
   /// @Default: `EdgeInsets.zero`
-  final EdgeInsets descriptionPadding;
+  final EdgeInsets? bodyPadding;
 
   /// Padding of footer
   ///
@@ -79,7 +79,7 @@ class PageDecoration {
     this.imagePadding = const EdgeInsets.only(bottom: 24.0),
     this.contentMargin = const EdgeInsets.all(16.0),
     this.titlePadding = const EdgeInsets.only(top: 16.0, bottom: 24.0),
-    this.descriptionPadding = EdgeInsets.zero,
+    this.bodyPadding,
     this.footerPadding = const EdgeInsets.symmetric(vertical: 24.0),
     this.bodyAlignment = Alignment.topCenter,
     this.imageAlignment = Alignment.bottomCenter,
@@ -118,7 +118,7 @@ class PageDecoration {
       imagePadding: imagePadding ?? this.imagePadding,
       contentMargin: contentMargin ?? this.contentMargin,
       titlePadding: titlePadding ?? this.titlePadding,
-      descriptionPadding: descriptionPadding ?? this.descriptionPadding,
+      bodyPadding: descriptionPadding ?? this.bodyPadding,
       footerPadding: footerPadding ?? this.footerPadding,
       bodyAlignment: bodyAlignment ?? this.bodyAlignment,
       imageAlignment: imageAlignment ?? this.imageAlignment,

--- a/lib/src/ui/intro_content.dart
+++ b/lib/src/ui/intro_content.dart
@@ -33,8 +33,8 @@ class IntroContent extends StatelessWidget {
               page.decoration.titleTextStyle,
             ),
           ),
-          Padding(
-            padding: page.decoration.descriptionPadding,
+          Container(
+            padding: page.decoration.bodyPadding,
             child: _buildWidget(
               page.bodyWidget,
               page.body,


### PR DESCRIPTION
I wanted to use introduction_screen with an `Expanded` `bodyWidget` to make sure I am using all the available space for the `bodyWidget`, but the widget tree was `Column -> Padding -> BodyWidget`. In this case I cannot use `Expanded` because it would have an unbounded height. So I changed it to `Column -> Container -> BodyWidget` where the container has a nullable padding, meaning that if the user leaves it null (as it is by default) the container will not build an inner `Padding` widget and would allow me to use `Expanded` as a body widget.

I also renamed `descriptionPadding` to `bodyPadding` since it was only used for setting the body padding and nothing else.