### PR TITLE
Add skipStyle, nextStyle and doneStyle IntroButton style parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,9 @@ This is all parameters you can add :
 - Change skip button color, by adding `skipColor: Colors.red` parameter.
 - Change next button color, by adding `nextColor: Colors.green` parameter.
 - Change done button color, by adding `doneColor: Colors.blue` parameter.
+- Change skip button style, by adding `skipStyle: TextButton.styleFrom(alignment: Alignment.centerLeft)` parameter.
+- Change next button style, by adding `nextStyle: TextButton.styleFrom(alignment: Alignment.centerRight)` parameter.
+- Change done button style, by adding `doneStyle: TextButton.styleFrom(splashFactory: NoSplash.splashFactory)` parameter.
 - Enable or disable SafeArea on top, by adding `isTopSafeArea: true` parameter (Default `false`).
 - Enable or disable SafeArea on bottom, by adding `isBottomSafeArea: true` parameter. (Default `false`)
 - Customize margin of controls's container, by adding `controlsMargin: EdgeInsets.all(16.0)` parameter. (Default `EdgeInsets.zero`)

--- a/lib/src/introduction_screen.dart
+++ b/lib/src/introduction_screen.dart
@@ -21,9 +21,6 @@ class IntroductionScreen extends StatefulWidget {
   /// Done button
   final Widget? done;
 
-  /// Done button style
-  final ButtonStyle? doneStyle;
-
   /// Callback when Skip button is pressed
   final VoidCallback? onSkip;
 
@@ -33,14 +30,8 @@ class IntroductionScreen extends StatefulWidget {
   /// Skip button
   final Widget? skip;
 
-  /// Skip button style
-  final ButtonStyle? skipStyle;
-
   /// Next button
   final Widget? next;
-
-  /// Next button style
-  final ButtonStyle? nextStyle;
 
   /// Is the Skip button should be display
   ///
@@ -123,6 +114,15 @@ class IntroductionScreen extends StatefulWidget {
 
   /// Color of done button
   final Color? doneColor;
+
+  /// Done button style
+  final ButtonStyle? doneStyle;
+
+  /// Skip button style
+  final ButtonStyle? skipStyle;
+
+  /// Next button style
+  final ButtonStyle? nextStyle;
 
   /// Enable or disabled top SafeArea
   ///

--- a/lib/src/introduction_screen.dart
+++ b/lib/src/introduction_screen.dart
@@ -21,6 +21,9 @@ class IntroductionScreen extends StatefulWidget {
   /// Done button
   final Widget? done;
 
+  /// Done button style
+  final ButtonStyle? doneStyle;
+
   /// Callback when Skip button is pressed
   final VoidCallback? onSkip;
 
@@ -30,8 +33,14 @@ class IntroductionScreen extends StatefulWidget {
   /// Skip button
   final Widget? skip;
 
+  /// Skup button style
+  final ButtonStyle? skipStyle;
+
   /// Next button
   final Widget? next;
+
+  /// Next button style
+  final ButtonStyle? nextStyle;
 
   /// Is the Skip button should be display
   ///
@@ -188,6 +197,9 @@ class IntroductionScreen extends StatefulWidget {
     this.skipColor,
     this.nextColor,
     this.doneColor,
+    this.skipStyle,
+    this.nextStyle,
+    this.doneStyle,
     this.isTopSafeArea = false,
     this.isBottomSafeArea = false,
     this.controlsMargin = EdgeInsets.zero,
@@ -291,18 +303,21 @@ class IntroductionScreenState extends State<IntroductionScreen> {
     final skipBtn = IntroButton(
       child: widget.skip,
       color: widget.skipColor ?? widget.color,
+      style: widget.skipStyle,
       onPressed: isSkipBtn ? _onSkip : null,
     );
 
     final nextBtn = IntroButton(
       child: widget.next,
       color: widget.nextColor ?? widget.color,
+      style: widget.nextStyle,
       onPressed: widget.showNextButton && !_isScrolling ? next : null,
     );
 
     final doneBtn = IntroButton(
       child: widget.done,
       color: widget.doneColor ?? widget.color,
+      style: widget.doneStyle,
       onPressed: widget.showDoneButton && !_isScrolling ? widget.onDone : null,
     );
 

--- a/lib/src/introduction_screen.dart
+++ b/lib/src/introduction_screen.dart
@@ -33,7 +33,7 @@ class IntroductionScreen extends StatefulWidget {
   /// Skip button
   final Widget? skip;
 
-  /// Skup button style
+  /// Skip button style
   final ButtonStyle? skipStyle;
 
   /// Next button

--- a/lib/src/ui/intro_button.dart
+++ b/lib/src/ui/intro_button.dart
@@ -4,21 +4,28 @@ class IntroButton extends StatelessWidget {
   final VoidCallback? onPressed;
   final Widget? child;
   final Color? color;
+  final ButtonStyle? style;
 
-  const IntroButton({Key? key, this.onPressed, this.child, this.color})
-      : super(key: key);
+  const IntroButton({
+    Key? key,
+    this.onPressed,
+    this.child,
+    this.color,
+    this.style,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return TextButton(
       onPressed: onPressed,
-      child: child ?? SizedBox(),
-      style: TextButton.styleFrom(
-        primary: color,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(8.0),
-        ),
-      ),
+      child: child ?? const SizedBox(),
+      style: style?.merge(TextButton.styleFrom(primary: color))
+          ?? TextButton.styleFrom(
+            primary: color,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8.0),
+            ),
+          ),
     );
   }
 }


### PR DESCRIPTION
Add paramters to override the styles of the `skip`, `next` and `done` buttons, e.g.

```dart
IntroductionScreen(
  // ... other config
  skipStyle: TextButton.styleFrom(
    alignment: Alignment.centerLeft,
  ),
  nextStyle: TextButton.styleFrom(
    alignment: Alignment.centerRight,
  ),
  doneStyle: TextButton.styleFrom(
    splashFactory: NoSplash.splashFactory,
  ),
)
```

These styles are then merged with `color` parameter and/or specific `skipColor`, `nextColor` and `doneColor`.

This also addresses #75