### PR TITLE
Add button semantics to IntroButton

### DIFF
--- a/lib/src/ui/intro_button.dart
+++ b/lib/src/ui/intro_button.dart
@@ -18,6 +18,7 @@ class IntroButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return Semantics(
       label: semanticLabel,
+      button: true,
       child: TextButton(
         onPressed: onPressed,
         child: child,


### PR DESCRIPTION
I noticed that the Skip and Next buttons didn't have a type, so I `button: true` to the `Semantics` of the `IntroButton`