### PR TITLE
Fixed double reading of buttons by screen readers.

### DIFF
--- a/lib/src/ui/intro_button.dart
+++ b/lib/src/ui/intro_button.dart
@@ -16,17 +16,19 @@ class IntroButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Semantics(
-      label: semanticLabel,
-      button: true,
-      child: TextButton(
-        onPressed: onPressed,
-        child: child,
-        style: TextButton.styleFrom(
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(8.0),
+    return MergeSemantics(
+      child: Semantics(
+          label: semanticLabel,
+          button: true,
+          child: TextButton(
+            onPressed: onPressed,
+            child: child,
+            style: TextButton.styleFrom(
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8.0),
+              ),
+            ).merge(style),
           ),
-        ).merge(style),
       ),
     );
   }


### PR DESCRIPTION


https://user-images.githubusercontent.com/46194381/158031848-f91b1d75-a970-4b75-a776-7e373b4be48d.mp4

The Semantics and TextButton widgets create two different semantic nodes that are read by the screen reader as two buttons instead of a single one. MergeSemantics merges the semantic nodes into a single node resulting in a single button read by the screen reader.

_Tested with the example project by alternately adding the nextSemantic, skipSemantic, backSemantic, doneSemantic properties to the IntroductionScreen class._