### PR TITLE
Hiding Of Skip Button Is Now Handled By A Visibility Widget So It Doesn't Jump Around

### DIFF
--- a/lib/src/introduction_screen.dart
+++ b/lib/src/introduction_screen.dart
@@ -370,15 +370,21 @@ class IntroductionScreenState extends State<IntroductionScreen> {
     final isLastPage = (_currentPage.round() == getPagesLength() - 1);
 
     Widget? leftBtn;
-    if (widget.showSkipButton && !_isSkipPressed && !isLastPage) {
-      leftBtn = widget.overrideSkip ??
-          IntroButton(
-            child: widget.skip!,
-            style: widget.baseBtnStyle?.merge(widget.skipStyle) ??
-                widget.skipStyle,
-            semanticLabel: widget.skipSemantic,
-            onPressed: _onSkip,
-          );
+    if (widget.showSkipButton && !_isSkipPressed) {
+      leftBtn = Visibility(
+        visible: !isLastPage,
+        maintainState: true, // Needs to be true to maintain animation
+        maintainAnimation: true, // Needs to be true to maintain size
+        maintainSize: true,
+        child: widget.overrideSkip ??
+            IntroButton(
+              child: widget.skip!,
+              style: widget.baseBtnStyle?.merge(widget.skipStyle) ??
+                  widget.skipStyle,
+              semanticLabel: widget.skipSemantic,
+              onPressed: _onSkip,
+            ),
+      );
     } else if (widget.showBackButton && _currentPage.round() > 0) {
       leftBtn = widget.overrideBack ??
           IntroButton(

--- a/lib/src/introduction_screen.dart
+++ b/lib/src/introduction_screen.dart
@@ -370,9 +370,9 @@ class IntroductionScreenState extends State<IntroductionScreen> {
     final isLastPage = (_currentPage.round() == getPagesLength() - 1);
 
     Widget? leftBtn;
-    if (widget.showSkipButton && !_isSkipPressed) {
+    if (widget.showSkipButton) {
       leftBtn = Visibility(
-        visible: !isLastPage,
+        visible: !isLastPage && !_isSkipPressed,
         maintainState: true, // Needs to be true to maintain animation
         maintainAnimation: true, // Needs to be true to maintain size
         maintainSize: true,


### PR DESCRIPTION
This issue shows the problem:

https://github.com/Pyozer/introduction_screen/issues/118

They solved it some other way. This pull request solves it by replacing the widget with a visibility widget allowing it to maintain its size even if hidden.