### PR TITLE
Add resizeToAvoidBottomInset option to for better keyboard support

### DIFF
--- a/lib/src/introduction_screen.dart
+++ b/lib/src/introduction_screen.dart
@@ -167,6 +167,11 @@ class IntroductionScreen extends StatefulWidget {
   /// @Default `false`
   final bool isBottomSafeArea;
 
+  /// Enable or disable content resizing for bottom inset (e.g. keyboard)
+  ///
+  /// @Default `true`
+  final bool resizeToAvoidBottomInset;
+
   /// Controls position
   ///
   /// @Default `Position(left: 0, right: 0, bottom: 0)`
@@ -248,6 +253,7 @@ class IntroductionScreen extends StatefulWidget {
     this.backSemantic,
     this.isTopSafeArea = false,
     this.isBottomSafeArea = false,
+    this.resizeToAvoidBottomInset = true,
     this.controlsPosition = const Position(left: 0, right: 0, bottom: 0),
     this.controlsMargin = EdgeInsets.zero,
     this.controlsPadding = const EdgeInsets.all(16.0),
@@ -413,6 +419,7 @@ class IntroductionScreenState extends State<IntroductionScreen> {
 
     return Scaffold(
       backgroundColor: widget.globalBackgroundColor,
+      resizeToAvoidBottomInset: widget.resizeToAvoidBottomInset,
       body: Stack(
         children: [
           Positioned.fill(


### PR DESCRIPTION
For some use-cases, it is desirable to have a simple text input during the onboarding.

By default, scaffolding will resize all its content to avoid the keyboard overlapping any of the content.   
For these kind of screens however, this leads to a very weird, squished UI and often layout constraint issues.

Adding this option allows users to set `resizeToAvoidBottomInset` as `false` to have the keyboard overlay the bottom part of the onboarding screen instead of forcing a resize.

This is directly passed to [this option of the Scaffolding widget](https://api.flutter.dev/flutter/material/Scaffold/resizeToAvoidBottomInset.html)