### PR TITLE
Fix bounce effect that occurs after last page

### DIFF
--- a/lib/src/introduction_screen.dart
+++ b/lib/src/introduction_screen.dart
@@ -368,7 +368,7 @@ class IntroductionScreenState extends State<IntroductionScreen> {
     if (_durationInt != null) {
       Duration _duration = Duration(milliseconds: _durationInt);
 
-      for (int i = 0; i < widget.pages!.length; i++) {
+      for (int i = 0; i < widget.pages!.length - 1; i++) {
         await Future.delayed(_duration);
         if (!_isSkipPressed && !_isScrolling) {
           _pageController.nextPage(


### PR DESCRIPTION
When autoscroll is enabled, it scrolls beyond the last page. So, scrolling should stop when the last page is displayed.