### PR TITLE
feat(intro_page): add option to adjust page margin

### DIFF
--- a/lib/src/model/page_decoration.dart
+++ b/lib/src/model/page_decoration.dart
@@ -39,6 +39,11 @@ class PageDecoration {
   /// @Default `EdgeInsets.all(16.0)`
   final EdgeInsets contentMargin;
 
+  /// Margin for page
+  ///
+  /// @Default `EdgeInsets.only(bottom: 60.0)`
+  final EdgeInsets? pageMargin;
+
   /// Padding of title
   ///
   /// @Default `EdgeInsets.only(top: 16.0, bottom: 24.0)`
@@ -89,6 +94,7 @@ class PageDecoration {
     this.footerFit = FlexFit.loose,
     this.imagePadding = const EdgeInsets.only(bottom: 24.0),
     this.contentMargin = const EdgeInsets.all(16.0),
+    this.pageMargin = const EdgeInsets.only(bottom: 60.0),
     this.titlePadding = const EdgeInsets.only(top: 16.0, bottom: 24.0),
     this.bodyPadding,
     this.footerPadding = const EdgeInsets.symmetric(vertical: 24.0),
@@ -110,6 +116,7 @@ class PageDecoration {
     FlexFit? footerFit,
     EdgeInsets? imagePadding,
     EdgeInsets? contentMargin,
+    EdgeInsets? pageMargin,
     EdgeInsets? titlePadding,
     EdgeInsets? descriptionPadding,
     EdgeInsets? footerPadding,
@@ -134,6 +141,7 @@ class PageDecoration {
       footerFit: footerFit ?? this.footerFit,
       imagePadding: imagePadding ?? this.imagePadding,
       contentMargin: contentMargin ?? this.contentMargin,
+      pageMargin: pageMargin ?? this.pageMargin,
       titlePadding: titlePadding ?? this.titlePadding,
       bodyPadding: descriptionPadding ?? this.bodyPadding,
       footerPadding: footerPadding ?? this.footerPadding,

--- a/lib/src/ui/intro_page.dart
+++ b/lib/src/ui/intro_page.dart
@@ -72,7 +72,7 @@ class _IntroPageState extends State<IntroPage>
     return Container(
       color: page.decoration.pageColor,
       decoration: page.decoration.boxDecoration,
-      margin: const EdgeInsets.only(bottom: 60.0),
+      margin: page.decoration.pageMargin,
       child: Flex(
         direction:
             page.useRowInLandscape && orientation == Orientation.landscape


### PR DESCRIPTION
We've run into the problem that the bottom page margin is excessive on very small devices (see screenshot below). This PR introduces a new parameter to adjust that margin with the default value being the previous value.

![large-footer-example](https://github.com/Pyozer/introduction_screen/assets/52230969/9c74693e-4913-417d-8ea6-541a6917a1d3)
