### PR TITLE
feat(introduction_screen): Enable override* buttons to receive onPressed callback

### DIFF
--- a/lib/src/introduction_screen.dart
+++ b/lib/src/introduction_screen.dart
@@ -42,28 +42,32 @@ class IntroductionScreen extends StatefulWidget {
 
   /// Override pre-made done button.
   /// You can what you want (button, text, image, ...)
-  final Widget? overrideDone;
+  final Widget Function(BuildContext context, Function()? onPressed)?
+      overrideDone;
 
   /// Skip button child for the pre-made TextButton
   final Widget? skip;
 
   /// Override pre-made skip button.
   /// You can what you want (button, text, image, ...)
-  final Widget? overrideSkip;
+  final Widget Function(BuildContext context, Function() onPressed)?
+      overrideSkip;
 
   /// Next button child for the pre-made TextButton
   final Widget? next;
 
   /// Override pre-made next button.
   /// You can what you want (button, text, image, ...)
-  final Widget? overrideNext;
+  final Widget Function(BuildContext context, Function()? onPressed)?
+      overrideNext;
 
   /// Back button child for the pre-made TextButton
   final Widget? back;
 
   /// Override pre-made back button.
   /// You can what you want (button, text, image, ...)
-  final Widget? overrideBack;
+  final Widget Function(BuildContext context, Function()? onPressed)?
+      overrideBack;
 
   /// Is the Skip button should be display
   ///
@@ -558,49 +562,53 @@ class IntroductionScreenState extends State<IntroductionScreen> {
         maintainAnimation: true,
         // Needs to be true to maintain size
         maintainSize: true,
-        child: widget.overrideSkip ??
-            IntroButton(
-              child: widget.skip!,
-              style: widget.baseBtnStyle?.merge(widget.skipStyle) ??
-                  widget.skipStyle,
-              semanticLabel: widget.skipSemantic,
-              onPressed: _onSkip,
-            ),
+        child: widget.overrideSkip != null
+            ? widget.overrideSkip!(context, _onSkip)
+            : IntroButton(
+                child: widget.skip!,
+                style: widget.baseBtnStyle?.merge(widget.skipStyle) ??
+                    widget.skipStyle,
+                semanticLabel: widget.skipSemantic,
+                onPressed: _onSkip,
+              ),
       );
     } else if (widget.showBackButton &&
         getCurrentPage() > 0 &&
         widget.canProgress(getCurrentPage())) {
-      leftBtn = widget.overrideBack ??
-          IntroButton(
-            child: widget.back!,
-            style: widget.baseBtnStyle?.merge(widget.backStyle) ??
-                widget.backStyle,
-            semanticLabel: widget.backSemantic,
-            onPressed: !_isScrolling ? previous : null,
-          );
+      leftBtn = widget.overrideBack != null
+          ? widget.overrideBack!(context, !_isScrolling ? previous : null)
+          : IntroButton(
+              child: widget.back!,
+              style: widget.baseBtnStyle?.merge(widget.backStyle) ??
+                  widget.backStyle,
+              semanticLabel: widget.backSemantic,
+              onPressed: !_isScrolling ? previous : null,
+            );
     }
 
     Widget? rightBtn;
     if (isLastPage && widget.showDoneButton) {
-      rightBtn = widget.overrideDone ??
-          IntroButton(
-            child: widget.done!,
-            style: widget.baseBtnStyle?.merge(widget.doneStyle) ??
-                widget.doneStyle,
-            semanticLabel: widget.doneSemantic,
-            onPressed: !_isScrolling ? widget.onDone : null,
-          );
+      rightBtn = widget.overrideDone != null
+          ? widget.overrideDone!(context, !_isScrolling ? widget.onDone : null)
+          : IntroButton(
+              child: widget.done!,
+              style: widget.baseBtnStyle?.merge(widget.doneStyle) ??
+                  widget.doneStyle,
+              semanticLabel: widget.doneSemantic,
+              onPressed: !_isScrolling ? widget.onDone : null,
+            );
     } else if (!isLastPage &&
         widget.showNextButton &&
         widget.canProgress(getCurrentPage())) {
-      rightBtn = widget.overrideNext ??
-          IntroButton(
-            child: widget.next!,
-            style: widget.baseBtnStyle?.merge(widget.nextStyle) ??
-                widget.nextStyle,
-            semanticLabel: widget.nextSemantic,
-            onPressed: !_isScrolling ? next : null,
-          );
+      rightBtn = widget.overrideNext != null
+          ? widget.overrideNext!(context, !_isScrolling ? next : null)
+          : IntroButton(
+              child: widget.next!,
+              style: widget.baseBtnStyle?.merge(widget.nextStyle) ??
+                  widget.nextStyle,
+              semanticLabel: widget.nextSemantic,
+              onPressed: !_isScrolling ? next : null,
+            );
     }
 
     final pages = widget.pages


### PR DESCRIPTION
## 🚀 Summary

This PR enhances the existing `override*` button APIs (`overrideDone`, `overrideNext`, `overrideSkip`, `overrideBack`) by passing them an `onPressed` callback. Consumers can now supply fully custom widgets **and** wire up the built-in navigation logic, without having to manually hook into `IntroductionScreenState`.

---

## 🧩 Motivation

Currently, `overrideDone` (and its siblings) accept a `Widget?`, which makes it impossible to integrate the built-in navigation behavior (e.g. advancing to the next page, skipping). Users who want a custom button must:

1. Provide their own widget.
2. Manually call navigation methods on the `GlobalKey<IntroductionScreenState>`.

This is cumbersome and error-prone. By passing the `onPressed` handler directly to the override builder, we:

* Promote **DRY**: reuse existing navigation callbacks.
* Simplify usage: consumer only needs to define appearance.
* Ensure consistent behavior across all buttons.

---

## 🛠️ Implementation

* **Signature change**

  ```dart
  // Before
  final Widget? overrideDone;

  // After
  final Widget Function(BuildContext context, VoidCallback? onPressed)? overrideDone;
  ```

* Apply the same pattern to:

  * `overrideNext`
  * `overrideSkip`
  * `overrideBack`

* Internally, when rendering an override button:

  ```dart
  if (overrideDone != null) {
    child = overrideDone!(context, _handleDone);
  } else {
    child = done;
  }
  ```

* Where `_handleDone` is the existing navigation callback that invokes `onDone` and advances the screen.

---

## 🔍 Usage Example

```dart
IntroductionScreen(
  pages: pages,
  overrideDone: (context, onPressed) {
    return ElevatedButton.icon(
      icon: const Icon(Icons.check_circle),
      label: const Text("Let’s Go!"),
      style: ElevatedButton.styleFrom(
        primary: Colors.green,
        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
      ),
      onPressed: onPressed, // Automatically calls `onDone`
    );
  },
  onDone: () {
    // Custom completion logic
  },
);
```

All other override parameters work identically:

```dart
overrideNext: (ctx, onPressed) => MyCustomNextButton(onPressed: onPressed),
overrideSkip: (ctx, onPressed) => TextButton(onPressed: onPressed, child: Text("Skip")),
overrideBack: (ctx, onPressed) => IconButton(icon: Icon(Icons.arrow_back), onPressed: onPressed),
```

