### PR TITLE
feat: Add backgroundImageWidget property for custom background images

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -106,13 +106,31 @@ class OnBoardingPageState extends State<OnBoardingPage> {
           decoration: pageDecoration,
         ),
         PageViewModel(
-          title: "Full Screen Page",
+          title: "Full Screen Page with backgroundImage",
           body:
               "Pages can be full screen as well.\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc id euismod lectus, non tempor felis. Nam rutrum rhoncus est ac venenatis.",
           backgroundImage: backgroundImage,
           decoration: pageDecoration.copyWith(
             contentMargin: const EdgeInsets.symmetric(horizontal: 16),
-            bodyFlex: 2,
+            bodyFlex: 4,
+            imageFlex: 3,
+            safeArea: 100,
+          ),
+        ),
+        PageViewModel(
+          title: "Full Screen Page with backgroundImageWidget",
+          body:
+              "Pages can be full screen as well.\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc id euismod lectus, non tempor felis. Nam rutrum rhoncus est ac venenatis.",
+          backgroundImageWidget: Image.asset(
+            backgroundImage,
+            fit: BoxFit.cover,
+            height: double.infinity,
+            width: double.infinity,
+            alignment: Alignment.center,
+          ),
+          decoration: pageDecoration.copyWith(
+            contentMargin: const EdgeInsets.symmetric(horizontal: 16),
+            bodyFlex: 4,
             imageFlex: 3,
             safeArea: 100,
           ),

--- a/lib/src/model/page_view_model.dart
+++ b/lib/src/model/page_view_model.dart
@@ -26,6 +26,12 @@ class PageViewModel {
   /// Tips: can be used alone or as a background image together with the "image" parameter.
   final String? backgroundImage;
 
+  /// Background image widget of a page.
+  /// Spans all over the screen.
+  ///
+  /// Tips: can be used alone or as a background image together with the "image" parameter. Use this instead of backgroundImage for more flexibility
+  final Widget? backgroundImageWidget;
+
   /// Footer widget, you can add a button for example
   final Widget? footer;
 
@@ -52,6 +58,7 @@ class PageViewModel {
     this.bodyWidget,
     this.image,
     this.backgroundImage,
+    this.backgroundImageWidget,
     this.footer,
     this.reverse = false,
     this.decoration = const PageDecoration(),
@@ -78,5 +85,9 @@ class PageViewModel {
         assert(
             backgroundImage == null ||
                 isBackgroundImageAssetPathValid(backgroundImage),
-            "You must provide a valid image asset path");
+            "You must provide a valid image asset path"),
+        assert(
+          backgroundImageWidget == null || backgroundImage == null,
+          "You can not provide both backgroundImage and backgroundImageWidget.",
+        );
 }

--- a/lib/src/ui/intro_page.dart
+++ b/lib/src/ui/intro_page.dart
@@ -23,20 +23,33 @@ class _IntroPageState extends State<IntroPage>
   @override
   bool get wantKeepAlive => true;
 
+  Widget? _buildBackgroundImage() {
+    final page = widget.page;
+
+    if (page.backgroundImageWidget != null) {
+      return page.backgroundImageWidget!;
+    }
+
+    if (page.backgroundImage != null) {
+      return Image.asset(
+        page.backgroundImage!,
+        fit: BoxFit.cover,
+        height: double.infinity,
+        width: double.infinity,
+        alignment: Alignment.center,
+      );
+    }
+
+    return null;
+  }
+
   Widget _buildStack() {
     final PageViewModel page = widget.page;
     final content = IntroContent(page: page, isFullScreen: true);
 
     return Stack(
       children: [
-        if (page.backgroundImage != null)
-          Image.asset(
-            page.backgroundImage!,
-            fit: BoxFit.cover,
-            height: double.infinity,
-            width: double.infinity,
-            alignment: Alignment.center,
-          ),
+        if (_buildBackgroundImage() != null) _buildBackgroundImage()!,
         if (page.image != null) page.image!,
         Positioned.fill(
           child: Column(
@@ -136,7 +149,8 @@ class _IntroPageState extends State<IntroPage>
     super.build(context);
 
     if (widget.page.decoration.fullScreen ||
-        widget.page.backgroundImage != null) {
+        widget.page.backgroundImage != null ||
+        widget.page.backgroundImageWidget != null) {
       return _buildStack();
     }
     return _buildFlex(context);


### PR DESCRIPTION
## What
Adds a new `backgroundImageWidget` property to `PageViewModel` that accepts any widget as a background image.

## Why
The existing `backgroundImage` parameter uses hardcoded values for `BoxFit`, `width`, `height`, and `alignment`. This new property gives full control over image properties.

## Usage
```dart
PageViewModel(
  backgroundImageWidget: Image.asset(
    'assets/background.jpg',
    fit: BoxFit.contain,
    width: 300,
    alignment: Alignment.topCenter,
  ),
  // ...
)
```